### PR TITLE
a fix for failure to compile with OpenJDK11

### DIFF
--- a/src/main/java/blogspot/software_and_algorithms/stern_library/data_structure/ThriftyList.java
+++ b/src/main/java/blogspot/software_and_algorithms/stern_library/data_structure/ThriftyList.java
@@ -1027,7 +1027,7 @@ public class ThriftyList<T> extends AbstractList<T> implements List<T>,
    */
   @Override
   public T[] toArray() {
-    return toArray(null);
+    return (T[]) toArray((Object[]) null);
   }
 
   /**


### PR DESCRIPTION
The current version of the library fails to compile with OpenJDK11 with the following error:

```
$ JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64  mvn clean compile
[...]
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/ostueker/software-and-algorithms/src/main/java/blogspot/software_and_algorithms/stern_library/data_structure/ThriftyList.java:[1030,12] reference to toArray is ambiguous
  both method <T>toArray(java.util.function.IntFunction<T[]>) in java.util.Collection and method <U>toArray(U[]) in blogspot.software_and_algorithms.stern_library.data_structure.ThriftyList match
[INFO] 1 error
[INFO] -------------------------------------------------------------
[...]
```

This patch seems to fix the issue, though I don't understand the code nearly well enough to judge whether my solution does the right thing. The tests however, still pass after applying the patch.